### PR TITLE
Remove header sections highlight on hover

### DIFF
--- a/styles/_notifications.scss
+++ b/styles/_notifications.scss
@@ -74,10 +74,6 @@
             width:180px;
         }
 
-        &:hover {
-            background-color:$rocketblue;
-        }
-
         a {
             padding:0 10px;
             display:inline-block;
@@ -114,10 +110,6 @@
         // Small screens
         @media screen and (max-width: $break-small) {
             left:180px;
-        }
-
-        &:hover {
-            background-color:$rocketblue;
         }
 
         a {


### PR DESCRIPTION
I think that it is confusing, suggesting that the whole section is clickable. Another thing to consider now is making the background color of this header the same as of the sidebar, which would reduce the number of colors and make the contrast between highlighted links and background.

What do you think?