### PR TITLE
Stopped subreddit bar from moving down 150 pixels when pinHeader is enabled in RES settings

### DIFF
--- a/styles/_header.scss
+++ b/styles/_header.scss
@@ -22,6 +22,7 @@ div#sr-header-area, .res-nightmode div#sr-header-area {
     text-transform:lowercase;
     line-height:$subredditNavigatorHeight;
     height:$subredditNavigatorHeight;
+    top: 0;
 
     .drop-choices.srdrop {
         border:none;


### PR DESCRIPTION
Currently, the new design causes parts of the header to float in the middle of the page when pinHeader is enabled in RES settings. This should fix it without affecting anything else.