### PR TITLE
Fixed positioning for Decronym's table

### DIFF
--- a/styles/_decronym.scss
+++ b/styles/_decronym.scss
@@ -1,0 +1,30 @@
+// Fixed positioning for Decronym table
+div.comment[data-author="Decronym"] .md {
+    h3 + h6 + h4 + p + table {
+        position: fixed;
+        top: 48px;
+        right: 25px;
+        width: 340px;
+        height: 99px;
+        font-size: 8px;
+        display: block;
+        background: #374148;
+        padding: 5px;
+        z-index: 1001;
+
+        thead {
+            display: none;
+        }
+        tbody {
+            display: block;
+            height: 89px;
+            overflow: auto;
+
+            td {
+                color: #ddd;
+                border-color: #ddd;
+                padding: 4px 7px;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Looks like this:
![Screenshot](https://cloud.githubusercontent.com/assets/235537/15074070/cd6a211c-1394-11e6-96fc-878bd47e0736.png)
