### PR TITLE
Display recycling symbol larger using <sup> on sidebar manifest

### DIFF
--- a/subreddits/styles/_events.scss
+++ b/subreddits/styles/_events.scss
@@ -14,6 +14,13 @@
             color:$gold;
             padding-top:3px;
         }
+
+        // Display recycling symbol larger
+        tr > td::nth-child(2) em sup {
+            font-size: 3em;
+            font-style: normal;
+            vertical-align: top;
+        }
     }
 
     thead {


### PR DESCRIPTION
Requested by /u/randomstonerfromaus [here](https://www.reddit.com/r/spacex/comments/5rcyea/rspacex_spaceflight_questions_news_february_2017/ddfm2ir/?context=1). The CSS hijacks superscripts (`^♺`) inside the event description (gold line) to make the contents bigger (and non-italic), so the SES-10 line in the sidebar source should look like `March | SES-10 *Falcon 9, KSC LC-39A ^♺*`. That produces the following output:

![Screenshot](http://i.imgur.com/zoHADJX.png)

Signed-off-by: Rory Stolzenberg <rory@getfoodio.com>